### PR TITLE
Remove jQuery noconflict mode

### DIFF
--- a/Resources/Public/Script/JsFaqToggle.js
+++ b/Resources/Public/Script/JsFaqToggle.js
@@ -4,8 +4,6 @@
  *  Togglae FAQ
 */
 
-jQuery.noConflict();
-
 jQuery(document).ready(function(jQuery){
 
 	var plus		= 'tx-jsfaq-toggle-plus';


### PR DESCRIPTION
Removes jQuery noConflict mode which disables $ method for the whole TYPO3 instance (not only the this extension!)
