### PR TITLE
Fix wrong installation location (composer.json)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "typo3/cms-core": ">=6.2.0,<9.0"
   },
   "replace": {
-    "js-faq": "self.version",
+    "js_faq": "self.version",
     "typo3-ter/js-faq": "self.version"
   }
 }


### PR DESCRIPTION
Fixes the installation location, now it's installed in typo3conf/ext/js-faq and will now be installed to typo3conf/ext/js_faq.
All other dashes are correct and shouldn't be replaced with underscores.
