### PR TITLE
Added constraints in where clause to work with workspaces

### DIFF
--- a/Classes/Domain/Repository/FAQRepository.php
+++ b/Classes/Domain/Repository/FAQRepository.php
@@ -142,7 +142,7 @@ class FAQRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 			$field1		= 'uid, options, description, image';
 			$orderBy1	= ' sorting';
 			$table1		= 'tx_jsfaq_domain_model_content';
-			$where1		= ' deleted = 0 AND hidden = 0 AND faq = \'' . $value['uid'] . '\'';
+			$where1		= ' deleted = 0 AND hidden = 0 AND faq = \'' . $value['uid'] . '\'AND t3ver_state !=1 AND pid !=-1';
 
 			$answers	= $this->configuration->falImages($GLOBALS['TYPO3_DB']->exec_SELECTgetRows($field1, $table1, $where1, '', $orderBy1), $table1, 'image');
 


### PR DESCRIPTION
Added the two hints to getFAQData():
-Any place where enableFields() are not used for selecting in the frontend you must at least check that t3ver_state != 1 so placeholders for new records are not displayed.
-Make sure never to select any record with pid = -1! (offline records - related to versioning).
see: https://docs.typo3.org/typo3cms/CoreApiReference/ApiOverview/Workspaces/Index.html#frontend-implementation-guidelines